### PR TITLE
Add string type for all enums

### DIFF
--- a/src/tap_apple_search_ads/schemas/Campaign.CountryOrRegionServingStateReasons.json
+++ b/src/tap_apple_search_ads/schemas/Campaign.CountryOrRegionServingStateReasons.json
@@ -9,7 +9,8 @@
         "SAPIN_LAW_AGENT_UNKNOWN",
         "SAPIN_LAW_FRENCH_BIZ_UNKNOWN",
         "SAPIN_LAW_FRENCH_BIZ"
-      ]
+      ],
+      "type": "string"
     }
   }
 }

--- a/src/tap_apple_search_ads/schemas/Campaign.json
+++ b/src/tap_apple_search_ads/schemas/Campaign.json
@@ -15,10 +15,12 @@
       "type": "integer"
     },
     "adChannelType": {
-      "enum": ["DISPLAY", "SEARCH"]
+      "enum": ["DISPLAY", "SEARCH"],
+      "type": "string"
     },
     "billingEvent": {
-      "enum": ["IMPRESSIONS", "TAPS"]
+      "enum": ["IMPRESSIONS", "TAPS"],
+      "type": "string"
     },
     "budgetAmount": {
       "$ref": "Money.json"
@@ -46,7 +48,8 @@
       "default": false
     },
     "displayStatus": {
-      "enum": ["DELETED", "ON_HOLD", "PAUSED", "RUNNING"]
+      "enum": ["DELETED", "ON_HOLD", "PAUSED", "RUNNING"],
+      "type": "string"
     },
     "endTime": {
       "type": ["null", "string"],
@@ -70,7 +73,8 @@
       "type": "integer"
     },
     "paymentModel": {
-      "enum": ["LOC", "PAYG", ""]
+      "enum": ["LOC", "PAYG", ""],
+      "type": "string"
     },
     "servingStateReasons": {
       "type": ["null", "array"],
@@ -103,11 +107,13 @@
           "SAPIN_LAW_FRENCH_BIZ",
           "TAX_VERIFICATION_PENDING",
           "TOTAL_BUDGET_EXHAUSTED"
-        ]
+        ],
+        "type": "string"
       }
     },
     "servingStatus": {
-      "enum": ["NOT_RUNNING", "RUNNING"]
+      "enum": ["NOT_RUNNING", "RUNNING"],
+      "type": "string"
     },
     "startTime": {
       "type": "string",
@@ -115,12 +121,14 @@
     },
     "status": {
       "enum": ["ENABLED", "PAUSED"],
+      "type": "string",
       "default": "ENABLED"
     },
     "supplySources": {
       "type": "array",
       "items": {
-        "enum": ["APPSTORE_SEARCH_RESULTS", "APPSTORE_SEARCH_TAB"]
+        "enum": ["APPSTORE_SEARCH_RESULTS", "APPSTORE_SEARCH_TAB"],
+        "type": "string"
       }
     }
   },

--- a/src/tap_apple_search_ads/schemas/Campaign_Flat.json
+++ b/src/tap_apple_search_ads/schemas/Campaign_Flat.json
@@ -15,10 +15,12 @@
       "type": "integer"
     },
     "adChannelType": {
-      "enum": ["DISPLAY", "SEARCH"]
+      "enum": ["DISPLAY", "SEARCH"],
+      "type": "string"
     },
     "billingEvent": {
-      "enum": ["IMPRESSIONS", "TAPS"]
+      "enum": ["IMPRESSIONS", "TAPS"],
+      "type": "string"
     },
     "budgetAmount_currency": {
       "$ref": "currency.json"
@@ -46,7 +48,8 @@
       "default": false
     },
     "displayStatus": {
-      "enum": ["DELETED", "ON_HOLD", "PAUSED", "RUNNING"]
+      "enum": ["DELETED", "ON_HOLD", "PAUSED", "RUNNING"],
+      "type": "string"
     },
     "endTime": {
       "type": ["null", "string"],
@@ -70,13 +73,15 @@
       "type": "integer"
     },
     "paymentModel": {
-      "enum": ["LOC", "PAYG", ""]
+      "enum": ["LOC", "PAYG", ""],
+      "type": "string"
     },
     "servingStateReasons": {
       "type": ["null", "string"]
     },
     "servingStatus": {
-      "enum": ["NOT_RUNNING", "RUNNING"]
+      "enum": ["NOT_RUNNING", "RUNNING"],
+      "type": "string"
     },
     "startTime": {
       "type": "string",
@@ -84,6 +89,7 @@
     },
     "status": {
       "enum": ["ENABLED", "PAUSED"],
+      "type": "string",
       "default": "ENABLED"
     },
     "supplySources": {

--- a/src/tap_apple_search_ads/schemas/Money.json
+++ b/src/tap_apple_search_ads/schemas/Money.json
@@ -13,7 +13,8 @@
         "RMB",
         "RUB",
         "USD"
-      ]
+      ],
+      "type": "string"
     },
     "amount": {
       "type": "string"

--- a/src/tap_apple_search_ads/schemas/Row.json
+++ b/src/tap_apple_search_ads/schemas/Row.json
@@ -106,13 +106,15 @@
         },
         "campaignStatus": {
           "enum": ["ENABLED", "PAUSED"],
+          "type": "string",
           "default": "ENABLED"
         },
         "app": {
           "$ref": "#/$defs/App"
         },
         "servingStatus": {
-          "enum": ["NOT_RUNNING", "RUNNING"]
+          "enum": ["NOT_RUNNING", "RUNNING"],
+          "type": "string"
         },
         "servingStateReasons": {
           "type": ["null", "array"],
@@ -145,7 +147,8 @@
               "SAPIN_LAW_FRENCH_BIZ",
               "TAX_VERIFICATION_PENDING",
               "TOTAL_BUDGET_EXHAUSTED"
-            ]
+            ],
+            "type": "string"
           }
         },
         "countriesOrRegions": {
@@ -165,16 +168,19 @@
           "$ref": "Money.json"
         },
         "displayStatus": {
-          "enum": ["DELETED", "ON_HOLD", "PAUSED", "RUNNING"]
+          "enum": ["DELETED", "ON_HOLD", "PAUSED", "RUNNING"],
+          "type": "string"
         },
         "supplySources": {
           "type": "array",
           "items": {
-            "enum": ["APPSTORE_SEARCH_RESULTS", "APPSTORE_SEARCH_TAB"]
+            "enum": ["APPSTORE_SEARCH_RESULTS", "APPSTORE_SEARCH_TAB"],
+            "type": "string"
           }
         },
         "adChannelType": {
-          "enum": ["DISPLAY", "SEARCH"]
+          "enum": ["DISPLAY", "SEARCH"],
+          "type": "string"
         },
         "orgId": {
           "type": "integer"
@@ -183,7 +189,8 @@
           "$ref": "Campaign.CountryOrRegionServingStateReasons.json"
         },
         "billingEvent": {
-          "enum": ["IMPRESSIONS", "TAPS"]
+          "enum": ["IMPRESSIONS", "TAPS"],
+          "type": "string"
         }
       }
     },

--- a/src/tap_apple_search_ads/schemas/currency.json
+++ b/src/tap_apple_search_ads/schemas/currency.json
@@ -1,3 +1,4 @@
 {
-  "enum": ["AUD", "CAD", "EUR", "GBP", "JPY", "MXN", "NZD", "RMB", "RUB", "USD"]
+  "enum": ["AUD", "CAD", "EUR", "GBP", "JPY", "MXN", "NZD", "RMB", "RUB", "USD"],
+  "type": "string"
 }


### PR DESCRIPTION
Even though `type` is not mandatory for `enum` in JSON schema, some loaders don't support fields without a type and are not able to infer it from the enumerated values.